### PR TITLE
确保稀疏token数正确

### DIFF
--- a/Qwen2_5_VL/qwen2_5_vl_HiPrune.py
+++ b/Qwen2_5_VL/qwen2_5_vl_HiPrune.py
@@ -574,6 +574,7 @@ class Qwen2_5_VisionTransformerPretrainedModel(Qwen2_5_VLPreTrainedModel):
                     attn_weights = attn_weights.sum(dim=0) 
                     attn_weights = attn_weights.view(attn_weights.shape[0]//4, -1).mean(dim=-1)
                     attn_weights = attn_weights[reverse_indices]
+                    attn_weights = F.softmax(attn_weights)
                 attn_list.append(attn_weights)
         hidden_states = self.merger(hidden_states)
         hidden_states = hidden_states[reverse_indices, :]

--- a/Qwen2_5_VL/qwen2_5_vl_HiPrune.py
+++ b/Qwen2_5_VL/qwen2_5_vl_HiPrune.py
@@ -569,9 +569,11 @@ class Qwen2_5_VisionTransformerPretrainedModel(Qwen2_5_VLPreTrainedModel):
             else:
                 hidden_states, attn_weights = blk(hidden_states, cu_seqlens=cu_seqlens_now, position_embeddings=position_embeddings)
                 with torch.no_grad():
-                    attn_weights = attn_weights.mean(dim=0)  
+                    attn_weights = attn_weights.mean(dim=0) # Average all heads
 
-                    attn_weights = attn_weights.sum(dim=0) 
+                    attn_weights = attn_weights.mean(dim=0)
+                    # Compute each token's attention, different from the sum in paper because the ones mask in line 1877
+                    # but sum and mean are equal since selection accords to the relative rank
                     attn_weights = attn_weights.view(attn_weights.shape[0]//4, -1).mean(dim=-1)
                     attn_weights = attn_weights[reverse_indices]
                     attn_weights = F.softmax(attn_weights)


### PR DESCRIPTION
<img width="1392" height="420" alt="image" src="https://github.com/user-attachments/assets/7da1316b-7313-453a-a9cb-f8b264cc8131" />
deep_attention不在[0,1]范围内的话，无法确保两个位置的稀疏token不会重复，导致总稀疏token数不正确，加上softmax可以解决这一问题